### PR TITLE
Replaced deprecated Theano.Param with Theano.In function

### DIFF
--- a/Theano Tutorial.ipynb
+++ b/Theano Tutorial.ipynb
@@ -15,18 +15,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/ayooshmac/anaconda/lib/python2.7/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.\n",
+      "  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')\n"
+     ]
+    }
+   ],
    "source": [
     "%matplotlib inline"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -60,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -101,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -126,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -148,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -181,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -206,7 +215,7 @@
     "# You can also set default parameter values\n",
     "# We'll cover theano.config.floatX later\n",
     "b_default = np.array([0, 0], dtype=theano.config.floatX)\n",
-    "linear_mix = theano.function([A, x, theano.Param(b, default=b_default)], [y, z])\n",
+    "linear_mix = theano.function([A, x, theano.In(b, value=b_default)], [y, z])\n",
     "# Supplying values for A, x, and b\n",
     "print(linear_mix(np.array([[1, 2, 3],\n",
     "                           [4, 5, 6]], dtype=theano.config.floatX), #A\n",
@@ -217,6 +226,15 @@
     "                           [4, 5, 6]], dtype=theano.config.floatX), #A\n",
     "                 np.array([1, 2, 3], dtype=theano.config.floatX))) #x"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1230,9 +1248,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [Root]",
    "language": "python",
-   "name": "python2"
+   "name": "Python [Root]"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1244,7 +1262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Replaced deprecated Theano.Param function with Theano.In function in the code sector under theano.tensor subheading.