### PR TITLE
Replaced Deprecated Theano.Param function with Theano.In

### DIFF
--- a/Theano Tutorial.ipynb
+++ b/Theano Tutorial.ipynb
@@ -206,7 +206,7 @@
     "# You can also set default parameter values\n",
     "# We'll cover theano.config.floatX later\n",
     "b_default = np.array([0, 0], dtype=theano.config.floatX)\n",
-    "linear_mix = theano.function([A, x, theano.Param(b, default=b_default)], [y, z])\n",
+    "linear_mix = theano.function([A, x, theano.In(b, default=b_default)], [y, z])\n",
     "# Supplying values for A, x, and b\n",
     "print(linear_mix(np.array([[1, 2, 3],\n",
     "                           [4, 5, 6]], dtype=theano.config.floatX), #A\n",


### PR DESCRIPTION
Replaced the deprecated Theano.Param function with Theano.In function in the code below "tensor" subheading. Sorry regarding the previous pull request. New to git, and screwed up monumentally so ended up forking the repo again, and issued a new pull request.
